### PR TITLE
API Cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,11 @@ source 'https://rubygems.org'
 gem 'rails', '4.2.3'
 gem 'pg'
 gem 'passenger'
-gem 'active_model_serializers', '~>0.10.0.rc2'
+# gem 'active_model_serializers', '~>0.10.0.rc2'
+gem 'active_model_serializers',
+  git: 'git@github.com:bravely/active_model_serializers.git',
+  branch: 'feature/default-json-api-to-dasherized-keys'
+  
 gem 'dotenv-rails'
 gem 'devise'
 gem 'lolesports-api', path: '~/Documents/lolesports-api'

--- a/Gemfile
+++ b/Gemfile
@@ -7,11 +7,12 @@ gem 'passenger'
 gem 'active_model_serializers',
   git: 'git@github.com:bravely/active_model_serializers.git',
   branch: 'feature/default-json-api-to-dasherized-keys'
-  
+
 gem 'dotenv-rails'
 gem 'devise'
 gem 'lolesports-api', path: '~/Documents/lolesports-api'
 gem 'slowweb'
+gem 'kaminari'
 
 group :development, :test do
   gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,9 @@ GEM
     highline (1.6.21)
     i18n (0.7.0)
     json (1.8.3)
+    kaminari (0.16.3)
+      actionpack (>= 3.0.0)
+      activesupport (>= 3.0.0)
     listen (3.0.3)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
@@ -317,6 +320,7 @@ DEPENDENCIES
   guard-brakeman
   guard-rspec
   guard-rubocop
+  kaminari
   lolesports-api!
   mailcatcher
   passenger

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: git@github.com:bravely/active_model_serializers.git
+  revision: 0e8d9adb853ab146c99f08dd1336555f31af1fdb
+  branch: feature/default-json-api-to-dasherized-keys
+  specs:
+    active_model_serializers (0.10.0.rc2)
+      activemodel (>= 4.0)
+
 PATH
   remote: ~/Documents/lolesports-api
   specs:
@@ -27,8 +35,6 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    active_model_serializers (0.10.0.rc2)
-      activemodel (>= 4.0)
     activejob (4.2.3)
       activesupport (= 4.2.3)
       globalid (>= 0.3.0)
@@ -301,7 +307,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  active_model_serializers (~> 0.10.0.rc2)
+  active_model_serializers!
   bundler-audit
   devise
   dotenv-rails

--- a/app/controllers/api/v1/games_controller.rb
+++ b/app/controllers/api/v1/games_controller.rb
@@ -1,6 +1,20 @@
 class Api::V1::GamesController < ApplicationController
   before_action :find_game, only: [:show]
 
+  def index
+    @games = Game.where(game_params)
+             .order(played_at: :desc)
+             .includes(:plays, :players, :blue_team, :red_team)
+             .page(params[:page])
+             .per(params[:limit] || 10)
+
+    @games = @games.with_player(player_param) if player_param
+
+    render json: @games,
+           include: %w(plays players blue_team red_team winner),
+           meta: { total_pages: @games.total_pages }
+  end
+
   def show
     render json: @game, include: %w(plays players blue_team red_team)
   end
@@ -9,5 +23,13 @@ class Api::V1::GamesController < ApplicationController
 
   def find_game
     @game = Game.find(params[:id])
+  end
+
+  def game_params
+    params.permit(:match_id, :finished)
+  end
+
+  def player_param
+    params[:player_id]
   end
 end

--- a/app/controllers/api/v1/games_controller.rb
+++ b/app/controllers/api/v1/games_controller.rb
@@ -4,14 +4,13 @@ class Api::V1::GamesController < ApplicationController
   def index
     @games = Game.where(game_params)
              .order(played_at: :desc)
-             .includes(:plays, :players, :blue_team, :red_team)
              .page(params[:page])
-             .per(params[:limit] || 10)
+             .per(params[:limit] || 5)
 
     @games = @games.with_player(player_param) if player_param
 
     render json: @games,
-           include: %w(plays players blue_team red_team winner),
+           each_serializer: GameSmallSerializer,
            meta: { total_pages: @games.total_pages }
   end
 
@@ -26,7 +25,7 @@ class Api::V1::GamesController < ApplicationController
   end
 
   def game_params
-    params.permit(:match_id, :finished)
+    params.permit(:match_id)
   end
 
   def player_param

--- a/app/controllers/api/v1/leagues_controller.rb
+++ b/app/controllers/api/v1/leagues_controller.rb
@@ -2,13 +2,13 @@ class Api::V1::LeaguesController < ApplicationController
   before_action :find_league, only: [:show]
 
   def index
-    @leagues = League.all
+    @leagues = League.all.includes(:series, :tournaments)
 
-    render json: @leagues
+    render json: @leagues, include: %w(series, tournaments)
   end
 
   def show
-    render json: @league, include: ['series']
+    render json: @league, include: %w(series tournaments)
   end
 
   private

--- a/app/controllers/api/v1/matches_controller.rb
+++ b/app/controllers/api/v1/matches_controller.rb
@@ -3,6 +3,7 @@ class Api::V1::MatchesController < ApplicationController
 
   def index
     @matches = Match.where(match_params)
+               .order(played_at: :desc)
                .includes(:tournament, :blue_team, :red_team, :winner, :games)
                .page(params[:page])
                .per(params[:limit] || 10)
@@ -11,7 +12,7 @@ class Api::V1::MatchesController < ApplicationController
   end
 
   def show
-    render json: @match, include: %w(games blue_team red_team)
+    render json: @match, serializer: SingleMatchSerializer, include: %w(games blue_team red_team)
   end
 
   private

--- a/app/controllers/api/v1/matches_controller.rb
+++ b/app/controllers/api/v1/matches_controller.rb
@@ -8,6 +8,8 @@ class Api::V1::MatchesController < ApplicationController
                .page(params[:page])
                .per(params[:limit] || 10)
 
+    @matches = @matches.with_team(team_param) if team_param
+
     render json: @matches, include: %w(tournaments, blue_team, red_team, winner, games)
   end
 
@@ -23,5 +25,9 @@ class Api::V1::MatchesController < ApplicationController
 
   def match_params
     params.permit(:tournament_id, :finished)
+  end
+
+  def team_param
+    params[:team_id]
   end
 end

--- a/app/controllers/api/v1/matches_controller.rb
+++ b/app/controllers/api/v1/matches_controller.rb
@@ -1,6 +1,15 @@
 class Api::V1::MatchesController < ApplicationController
   before_action :find_match, only: [:show]
 
+  def index
+    @matches = Match.where(match_params)
+               .includes(:tournament, :blue_team, :red_team, :winner, :games)
+               .page(params[:page])
+               .per(params[:limit] || 10)
+
+    render json: @matches, include: %w(tournaments, blue_team, red_team, winner, games)
+  end
+
   def show
     render json: @match, include: %w(games blue_team red_team)
   end
@@ -9,5 +18,9 @@ class Api::V1::MatchesController < ApplicationController
 
   def find_match
     @match = Match.find(params[:id])
+  end
+
+  def match_params
+    params.permit(:tournament_id, :finished)
   end
 end

--- a/app/controllers/api/v1/matches_controller.rb
+++ b/app/controllers/api/v1/matches_controller.rb
@@ -11,8 +11,8 @@ class Api::V1::MatchesController < ApplicationController
     @matches = @matches.with_team(team_param) if team_param
 
     render json: @matches,
-      include: %w(tournaments, blue_team, red_team, winner, games),
-      meta: { total_pages: @matches.total_pages }
+           include: %w(tournaments, blue_team, red_team, winner, games),
+           meta: { total_pages: @matches.total_pages }
   end
 
   def show

--- a/app/controllers/api/v1/matches_controller.rb
+++ b/app/controllers/api/v1/matches_controller.rb
@@ -10,7 +10,9 @@ class Api::V1::MatchesController < ApplicationController
 
     @matches = @matches.with_team(team_param) if team_param
 
-    render json: @matches, include: %w(tournaments, blue_team, red_team, winner, games)
+    render json: @matches,
+      include: %w(tournaments, blue_team, red_team, winner, games),
+      meta: { total_pages: @matches.total_pages }
   end
 
   def show

--- a/app/controllers/api/v1/matches_controller.rb
+++ b/app/controllers/api/v1/matches_controller.rb
@@ -4,14 +4,13 @@ class Api::V1::MatchesController < ApplicationController
   def index
     @matches = Match.where(match_params)
                .order(played_at: :desc)
-               .includes(:tournament, :blue_team, :red_team, :winner, :games)
                .page(params[:page])
                .per(params[:limit] || 10)
 
     @matches = @matches.with_team(team_param) if team_param
 
     render json: @matches,
-           include: %w(tournaments, blue_team, red_team, winner, games),
+           each_serializer: MatchSmallSerializer,
            meta: { total_pages: @matches.total_pages }
   end
 

--- a/app/controllers/api/v1/tournaments_controller.rb
+++ b/app/controllers/api/v1/tournaments_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::TournamentsController < ApplicationController
   before_action :find_tournament, only: [:show]
 
   def show
-    render json: @tournament
+    render json: @tournament, include: %w(league series winner matches)
   end
 
   private

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -10,6 +10,8 @@ class Game < ActiveRecord::Base
 
   after_create :assign_team_players
 
+  scope :with_player, -> (player_id) { where(plays: { player_id: player_id }).includes(:plays).references(:plays) }
+
   def blue_team_plays
     plays.where(team: blue_team)
   end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -42,8 +42,8 @@ class Game < ActiveRecord::Base
     update!(update_hash)
 
     plays.destroy_all
-    api_game.players.each do |api_play|
-      plays << Play.new.harvest(api_play, game: self)
+    api_game.players.each_with_index do |api_play, i|
+      plays << Play.new.harvest(api_play, game: self, position_index: i)
     end
 
     self

--- a/app/models/league.rb
+++ b/app/models/league.rb
@@ -1,6 +1,6 @@
 class League < ActiveRecord::Base
   has_many :teams
-  has_many :tournaments
+  has_many :tournaments, -> { order(last_played_at: :desc) }
   has_many :series
 
   def harvest(api_league = nil)

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -5,6 +5,8 @@ class Match < ActiveRecord::Base
   belongs_to :winner, class_name: 'Team'
   has_many :games
 
+  scope :with_team, -> (team_id) { where('blue_team_id = ? OR red_team_id = ?', team_id, team_id) }
+
   def harvest(api_match = nil, additional_values = {})
     api_match = LolesportsApi::Match.find(lolesports_id) unless api_match
     update_hash = {

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -1,5 +1,5 @@
 class Match < ActiveRecord::Base
-  belongs_to :tournament
+  belongs_to :tournament, touch: true
   belongs_to :blue_team, class_name: 'Team'
   belongs_to :red_team, class_name: 'Team'
   belongs_to :winner, class_name: 'Team'

--- a/app/models/play.rb
+++ b/app/models/play.rb
@@ -1,4 +1,26 @@
 class Play < ActiveRecord::Base
+  enum position: {
+    top: 0,
+    jungle: 1,
+    middle: 2,
+    marksman: 3,
+    support: 4
+  }
+
+  TEAM_POSITIONS = {
+    0 => :top,
+    1 => :jungle,
+    2 => :middle,
+    3 => :marksman,
+    4 => :support,
+
+    5 => :top,
+    6 => :jungle,
+    7 => :middle,
+    8 => :marksman,
+    9 => :support
+  }
+
   belongs_to :player
   belongs_to :game
   belongs_to :team
@@ -27,7 +49,9 @@ class Play < ActiveRecord::Base
       first_spell: api_play.spell0,
       second_spell: api_play.spell1,
       player: the_player,
-      team: Team.find_by(lolesports_id: api_play.team_id)
+      team: Team.find_by(lolesports_id: api_play.team_id),
+
+      position: TEAM_POSITIONS[additional_values.delete(:position_index)]
     }
     api_play.items.each_with_index { |item_id, i| update_hash["item#{i}".to_sym] = item_id }
     update! update_hash.merge!(additional_values)

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -15,7 +15,6 @@ class Player < ActiveRecord::Base
     'Support' => :support
   }
 
-  default_scope { order('handle ASC') }
   belongs_to :team
   has_many :plays
   has_many :games, through: :plays

--- a/app/models/tournament.rb
+++ b/app/models/tournament.rb
@@ -7,7 +7,6 @@ class Tournament < ActiveRecord::Base
   has_many :games, through: :matches
   belongs_to :winner, class_name: 'Team'
 
-  scope :first_five, -> { limit(5) }
   scope :ordered, -> { order(last_played_at: :desc) }
 
   after_touch :check_latest_match

--- a/app/models/tournament.rb
+++ b/app/models/tournament.rb
@@ -8,7 +8,7 @@ class Tournament < ActiveRecord::Base
   belongs_to :winner, class_name: 'Team'
 
   scope :first_five, -> { limit(5) }
-  scope :ordered, -> { order(starts_at: :desc) }
+  scope :ordered, -> { order(last_played_at: :desc) }
 
   def harvest(api_tournament = nil, additional_values = {})
     api_tournament = LolesportsApi::Tournament.find(lolesports_id) unless api_tournament

--- a/app/models/tournament.rb
+++ b/app/models/tournament.rb
@@ -7,6 +7,9 @@ class Tournament < ActiveRecord::Base
   has_many :games, through: :matches
   belongs_to :winner, class_name: 'Team'
 
+  scope :first_five, -> { limit(5) }
+  scope :ordered, -> { order(starts_at: :desc) }
+
   def harvest(api_tournament = nil, additional_values = {})
     api_tournament = LolesportsApi::Tournament.find(lolesports_id) unless api_tournament
     update_hash = {

--- a/app/serializers/game_for_single_match_serializer.rb
+++ b/app/serializers/game_for_single_match_serializer.rb
@@ -1,0 +1,6 @@
+class GameForSingleMatchSerializer < ActiveModel::Serializer
+  attributes :id, :played_at, :notes, :game_length, :game_number, :youtube_url
+  belongs_to :blue_team, serializer: TeamSmallSerializer
+  belongs_to :red_team, serializer: TeamSmallSerializer
+  belongs_to :winner, serializer: TeamSmallSerializer
+end

--- a/app/serializers/game_for_single_match_serializer.rb
+++ b/app/serializers/game_for_single_match_serializer.rb
@@ -1,4 +1,5 @@
 class GameForSingleMatchSerializer < ActiveModel::Serializer
+  cache key: 'games_single_match', expires_in: 1.hour
   attributes :id, :played_at, :notes, :game_length, :game_number, :youtube_url
   belongs_to :blue_team, serializer: TeamSmallSerializer
   belongs_to :red_team, serializer: TeamSmallSerializer

--- a/app/serializers/game_serializer.rb
+++ b/app/serializers/game_serializer.rb
@@ -1,12 +1,12 @@
 class GameSerializer < ActiveModel::Serializer
-  cache key: 'game', expires_in: 3.hours
+  cache key: 'game', expires_in: 1.hour
 
   attributes :id, :notes, :played_at, :game_length, :game_number, :youtube_url
 
   belongs_to :blue_team, serializer: TeamSmallSerializer
   belongs_to :red_team, serializer: TeamSmallSerializer
   belongs_to :winner, serializer: TeamSmallSerializer
-  belongs_to :match
+  belongs_to :match, serializer: MatchSmallSerializer
   has_many :players, serializer: PlayerSmallSerializer
   has_many :plays, serializer: PlaySmallSerializer
 end

--- a/app/serializers/game_serializer.rb
+++ b/app/serializers/game_serializer.rb
@@ -1,11 +1,12 @@
 class GameSerializer < ActiveModel::Serializer
   cache key: 'game', expires_in: 3.hours
-  attributes :id, :played_at, :notes, :game_length, :game_number, :youtube_url
 
-  belongs_to :blue_team
-  belongs_to :red_team
-  belongs_to :winner
+  attributes :id, :notes, :played_at, :game_length, :game_number, :youtube_url
+
+  belongs_to :blue_team, serializer: TeamSmallSerializer
+  belongs_to :red_team, serializer: TeamSmallSerializer
+  belongs_to :winner, serializer: TeamSmallSerializer
   belongs_to :match
-  has_many :players
-  has_many :plays
+  has_many :players, serializer: PlayerSmallSerializer
+  has_many :plays, serializer: PlaySmallSerializer
 end

--- a/app/serializers/game_serializer.rb
+++ b/app/serializers/game_serializer.rb
@@ -8,5 +8,5 @@ class GameSerializer < ActiveModel::Serializer
   belongs_to :winner, serializer: TeamSmallSerializer
   belongs_to :match, serializer: MatchSmallSerializer
   has_many :players, serializer: PlayerSmallSerializer
-  has_many :plays, serializer: PlaySmallSerializer
+  has_many :plays
 end

--- a/app/serializers/game_serializer.rb
+++ b/app/serializers/game_serializer.rb
@@ -1,5 +1,5 @@
 class GameSerializer < ActiveModel::Serializer
-  cache key: 'game', expires_in: 1.hour
+  cache key: 'games', expires_in: 1.hour
 
   attributes :id, :notes, :played_at, :game_length, :game_number, :youtube_url
 

--- a/app/serializers/game_small_serializer.rb
+++ b/app/serializers/game_small_serializer.rb
@@ -1,7 +1,3 @@
 class GameSmallSerializer < ActiveModel::Serializer
   attributes :id, :played_at, :notes, :game_length, :game_number, :youtube_url
-
-  belongs_to :blue_team, serializer: TeamSmallSerializer
-  belongs_to :red_team, serializer: TeamSmallSerializer
-  belongs_to :winner, serializer: TeamSmallSerializer
 end

--- a/app/serializers/game_small_serializer.rb
+++ b/app/serializers/game_small_serializer.rb
@@ -1,3 +1,4 @@
 class GameSmallSerializer < ActiveModel::Serializer
+  cache key: 'games_small', expires_in: 1.hour
   attributes :id, :played_at, :notes, :game_length, :game_number, :youtube_url
 end

--- a/app/serializers/game_small_serializer.rb
+++ b/app/serializers/game_small_serializer.rb
@@ -1,4 +1,8 @@
 class GameSmallSerializer < ActiveModel::Serializer
   cache key: 'games_small', expires_in: 1.hour
   attributes :id, :played_at, :notes, :game_length, :game_number, :youtube_url
+
+  belongs_to :blue_team
+  belongs_to :red_team
+  belongs_to :match
 end

--- a/app/serializers/game_small_serializer.rb
+++ b/app/serializers/game_small_serializer.rb
@@ -1,3 +1,7 @@
 class GameSmallSerializer < ActiveModel::Serializer
   attributes :id, :played_at, :notes, :game_length, :game_number, :youtube_url
+
+  belongs_to :blue_team, serializer: TeamSmallSerializer
+  belongs_to :red_team, serializer: TeamSmallSerializer
+  belongs_to :winner, serializer: TeamSmallSerializer
 end

--- a/app/serializers/league_serializer.rb
+++ b/app/serializers/league_serializer.rb
@@ -1,6 +1,7 @@
 class LeagueSerializer < ActiveModel::Serializer
+  cache key: 'leagues', expires_in: 1.hour
   attributes :id, :name, :region, :abbr
 
-  has_many :series
-  # has_many :tournaments
+  has_many :series, serializer: SeriesSmallSerializer
+  has_many :tournaments, serializer: TournamentSmallSerializer
 end

--- a/app/serializers/league_small_serializer.rb
+++ b/app/serializers/league_small_serializer.rb
@@ -1,0 +1,3 @@
+class LeagueSmallSerializer < ActiveModel::Serializer
+  attributes :id, :name, :region, :abbr
+end

--- a/app/serializers/league_small_serializer.rb
+++ b/app/serializers/league_small_serializer.rb
@@ -1,3 +1,4 @@
 class LeagueSmallSerializer < ActiveModel::Serializer
+  cache key: 'leagues_small', expires_in: 1.hour
   attributes :id, :name, :region, :abbr
 end

--- a/app/serializers/match_serializer.rb
+++ b/app/serializers/match_serializer.rb
@@ -1,5 +1,5 @@
 class MatchSerializer < ActiveModel::Serializer
-  cache key: 'match', expires_in: 1.hour
+  cache key: 'matches', expires_in: 1.hour
   attributes :id, :live, :finished, :name, :played_at, :max_games
 
   belongs_to :tournament, serializer: TournamentSmallSerializer

--- a/app/serializers/match_small_serializer.rb
+++ b/app/serializers/match_small_serializer.rb
@@ -1,9 +1,8 @@
-class MatchSerializer < ActiveModel::Serializer
+class MatchSmallSerializer < ActiveModel::Serializer
   attributes :id, :live, :finished, :name, :played_at, :max_games
 
   belongs_to :tournament, serializer: TournamentSmallSerializer
   belongs_to :blue_team, serializer: TeamSmallSerializer
   belongs_to :red_team, serializer: TeamSmallSerializer
   belongs_to :winner, serializer: TeamSmallSerializer
-  has_many :games, serializer: GameSmallSerializer
 end

--- a/app/serializers/match_small_serializer.rb
+++ b/app/serializers/match_small_serializer.rb
@@ -1,3 +1,4 @@
 class MatchSmallSerializer < ActiveModel::Serializer
+  cache key: 'matches_small', expires_in: 1.hour
   attributes :id, :live, :finished, :name, :played_at, :max_games
 end

--- a/app/serializers/match_small_serializer.rb
+++ b/app/serializers/match_small_serializer.rb
@@ -1,8 +1,3 @@
 class MatchSmallSerializer < ActiveModel::Serializer
   attributes :id, :live, :finished, :name, :played_at, :max_games
-
-  belongs_to :tournament, serializer: TournamentSmallSerializer
-  belongs_to :blue_team, serializer: TeamSmallSerializer
-  belongs_to :red_team, serializer: TeamSmallSerializer
-  belongs_to :winner, serializer: TeamSmallSerializer
 end

--- a/app/serializers/play_serializer.rb
+++ b/app/serializers/play_serializer.rb
@@ -1,4 +1,5 @@
 class PlaySerializer < ActiveModel::Serializer
+  cache key: 'plays', expires_in: 1.hour
   attributes :id, :kills, :deaths, :assists, :kda, :champion_id, :end_level,
              :total_gold, :minions_killed, :first_spell, :second_spell,
              :item0, :item1, :item2, :item3, :item4, :item5

--- a/app/serializers/play_serializer.rb
+++ b/app/serializers/play_serializer.rb
@@ -1,7 +1,7 @@
 class PlaySerializer < ActiveModel::Serializer
   cache key: 'plays', expires_in: 1.hour
   attributes :id, :kills, :deaths, :assists, :kda, :champion_id, :end_level,
-             :total_gold, :minions_killed, :first_spell, :second_spell,
+             :total_gold, :minions_killed, :position, :first_spell, :second_spell,
              :item0, :item1, :item2, :item3, :item4, :item5
 
   belongs_to :player

--- a/app/serializers/play_small_serializer.rb
+++ b/app/serializers/play_small_serializer.rb
@@ -1,0 +1,5 @@
+class PlaySmallSerializer < ActiveModel::Serializer
+  attributes :id, :kills, :deaths, :assists, :kda, :champion_id, :end_level,
+             :total_gold, :minions_killed, :first_spell, :second_spell,
+             :item0, :item1, :item2, :item3, :item4, :item5
+end

--- a/app/serializers/play_small_serializer.rb
+++ b/app/serializers/play_small_serializer.rb
@@ -1,4 +1,5 @@
 class PlaySmallSerializer < ActiveModel::Serializer
+  cache key: 'plays_small', expires_in: 1.hour
   attributes :id, :kills, :deaths, :assists, :kda, :champion_id, :end_level,
              :total_gold, :minions_killed, :first_spell, :second_spell,
              :item0, :item1, :item2, :item3, :item4, :item5

--- a/app/serializers/play_small_serializer.rb
+++ b/app/serializers/play_small_serializer.rb
@@ -1,6 +1,6 @@
 class PlaySmallSerializer < ActiveModel::Serializer
   cache key: 'plays_small', expires_in: 1.hour
   attributes :id, :kills, :deaths, :assists, :kda, :champion_id, :end_level,
-             :total_gold, :minions_killed, :first_spell, :second_spell,
+             :total_gold, :minions_killed, :position, :first_spell, :second_spell,
              :item0, :item1, :item2, :item3, :item4, :item5
 end

--- a/app/serializers/player_serializer.rb
+++ b/app/serializers/player_serializer.rb
@@ -1,7 +1,7 @@
 class PlayerSerializer < ActiveModel::Serializer
   cache key: 'players', expires_in: 1.hour
   attributes :id, :handle, :position, :first_name, :last_name, :season_wins,
-             :season_losses
+             :season_losses, :starter, :contract_expires_at
 
   belongs_to :team, serializer: TeamSmallSerializer
   # has_many :games

--- a/app/serializers/player_serializer.rb
+++ b/app/serializers/player_serializer.rb
@@ -1,4 +1,5 @@
 class PlayerSerializer < ActiveModel::Serializer
+  cache key: 'players', expires_in: 1.hour
   attributes :id, :handle, :position, :first_name, :last_name, :season_wins,
              :season_losses
 

--- a/app/serializers/player_serializer.rb
+++ b/app/serializers/player_serializer.rb
@@ -1,9 +1,6 @@
 class PlayerSerializer < ActiveModel::Serializer
-  attributes :id, :handle, :position
-  attribute :first_name, key: 'first-name'
-  attribute :last_name, key: 'last-name'
-  attribute :season_wins, key: 'season-wins'
-  attribute :season_losses, key: 'season-losses'
+  attributes :id, :handle, :position, :first_name, :last_name, :season_wins,
+             :season_losses
 
   belongs_to :team, serializer: TeamSmallSerializer
   # has_many :games

--- a/app/serializers/player_small_serializer.rb
+++ b/app/serializers/player_small_serializer.rb
@@ -1,7 +1,4 @@
 class PlayerSmallSerializer < ActiveModel::Serializer
-  attributes :id, :handle, :position
-  attribute :first_name, key: 'first-name'
-  attribute :last_name, key: 'last-name'
-  attribute :season_wins, key: 'season-wins'
-  attribute :season_losses, key: 'season-losses'
+  attributes :id, :handle, :position, :first_name, :last_name, :season_wins,
+             :season_losses
 end

--- a/app/serializers/player_small_serializer.rb
+++ b/app/serializers/player_small_serializer.rb
@@ -1,4 +1,5 @@
 class PlayerSmallSerializer < ActiveModel::Serializer
+  cache key: 'players_small', expires_in: 1.hour
   attributes :id, :handle, :position, :first_name, :last_name, :season_wins,
              :season_losses
 end

--- a/app/serializers/player_small_serializer.rb
+++ b/app/serializers/player_small_serializer.rb
@@ -1,5 +1,5 @@
 class PlayerSmallSerializer < ActiveModel::Serializer
   cache key: 'players_small', expires_in: 1.hour
   attributes :id, :handle, :position, :first_name, :last_name, :season_wins,
-             :season_losses
+             :season_losses, :starter, :contract_expires_at
 end

--- a/app/serializers/series_serializer.rb
+++ b/app/serializers/series_serializer.rb
@@ -1,4 +1,5 @@
 class SeriesSerializer < ActiveModel::Serializer
+  cache key: 'series', expires_in: 1.hour
   attributes :id, :name, :season, :finished
 
   belongs_to :league, serializer: LeagueSmallSerializer

--- a/app/serializers/series_serializer.rb
+++ b/app/serializers/series_serializer.rb
@@ -1,5 +1,6 @@
 class SeriesSerializer < ActiveModel::Serializer
   attributes :id, :name, :season, :finished
 
-  has_many :tournaments
+  belongs_to :league, serializer: LeagueSmallSerializer
+  has_many :tournaments, serializer: TournamentSmallSerializer
 end

--- a/app/serializers/series_small_serializer.rb
+++ b/app/serializers/series_small_serializer.rb
@@ -1,0 +1,3 @@
+class SeriesSmallSerializer < ActiveModel::Serializer
+  attributes :id, :name, :season, :finished
+end

--- a/app/serializers/series_small_serializer.rb
+++ b/app/serializers/series_small_serializer.rb
@@ -1,3 +1,4 @@
 class SeriesSmallSerializer < ActiveModel::Serializer
+  cache key: 'series_small', expires_in: 1.hour
   attributes :id, :name, :season, :finished
 end

--- a/app/serializers/single_match_serializer.rb
+++ b/app/serializers/single_match_serializer.rb
@@ -1,5 +1,5 @@
 class SingleMatchSerializer < ActiveModel::Serializer
-  cache key: 'single_match', expires_in: 1.hour
+  cache key: 'single_matches', expires_in: 1.hour
   attributes :id, :live, :finished, :name, :played_at, :max_games
 
   belongs_to :tournament, serializer: TournamentSmallSerializer

--- a/app/serializers/single_match_serializer.rb
+++ b/app/serializers/single_match_serializer.rb
@@ -1,10 +1,10 @@
-class MatchSerializer < ActiveModel::Serializer
-  cache key: 'match', expires_in: 1.hour
+class SingleMatchSerializer < ActiveModel::Serializer
+  cache key: 'single_match', expires_in: 1.hour
   attributes :id, :live, :finished, :name, :played_at, :max_games
 
   belongs_to :tournament, serializer: TournamentSmallSerializer
   belongs_to :blue_team, serializer: TeamSmallSerializer
   belongs_to :red_team, serializer: TeamSmallSerializer
   belongs_to :winner, serializer: TeamSmallSerializer
-  has_many :games, serializer: GameSmallSerializer
+  has_many :games, serializer: GameForSingleMatchSerializer
 end

--- a/app/serializers/team_serializer.rb
+++ b/app/serializers/team_serializer.rb
@@ -1,6 +1,6 @@
 class TeamSerializer < ActiveModel::Serializer
   cache key: 'teams', expires_in: 1.hour
-  attributes :id, :name, :location
+  attributes :id, :name, :location, :acronym
 
   belongs_to :league, serializer: LeagueSmallSerializer
   has_many :players, serializer: PlayerSmallSerializer

--- a/app/serializers/team_serializer.rb
+++ b/app/serializers/team_serializer.rb
@@ -1,7 +1,7 @@
 class TeamSerializer < ActiveModel::Serializer
   attributes :id, :name, :location
 
-  belongs_to :league
+  belongs_to :league, serializer: LeagueSmallSerializer
   has_many :players, serializer: PlayerSmallSerializer
-  # has_many :matches
+  has_many :matches, serializer: MatchSmallSerializer
 end

--- a/app/serializers/team_serializer.rb
+++ b/app/serializers/team_serializer.rb
@@ -1,4 +1,5 @@
 class TeamSerializer < ActiveModel::Serializer
+  cache key: 'teams', expires_in: 1.hour
   attributes :id, :name, :location
 
   belongs_to :league, serializer: LeagueSmallSerializer

--- a/app/serializers/team_small_serializer.rb
+++ b/app/serializers/team_small_serializer.rb
@@ -1,4 +1,4 @@
 class TeamSmallSerializer < ActiveModel::Serializer
-  cache key: 'team_small', expires_in: 1.hour
+  cache key: 'teams_small', expires_in: 1.hour
   attributes :id, :name, :location
 end

--- a/app/serializers/team_small_serializer.rb
+++ b/app/serializers/team_small_serializer.rb
@@ -1,3 +1,4 @@
 class TeamSmallSerializer < ActiveModel::Serializer
+  cache key: 'team_small', expires_in: 1.hour
   attributes :id, :name, :location
 end

--- a/app/serializers/team_small_serializer.rb
+++ b/app/serializers/team_small_serializer.rb
@@ -1,4 +1,4 @@
 class TeamSmallSerializer < ActiveModel::Serializer
   cache key: 'teams_small', expires_in: 1.hour
-  attributes :id, :name, :location
+  attributes :id, :name, :location, :acronym
 end

--- a/app/serializers/tournament_serializer.rb
+++ b/app/serializers/tournament_serializer.rb
@@ -1,9 +1,9 @@
 class TournamentSerializer < ActiveModel::Serializer
-  attributes :id, :starts_at, :ends_at, :name, :finished, :season
+  attributes :id, :name, :finished, :season, :starts_at, :ends_at
 
-  belongs_to :league
-  belongs_to :series
-  belongs_to :winner
-  # has_many :matches
+  belongs_to :league, serializer: LeagueSmallSerializer
+  belongs_to :series, serializer: SeriesSmallSerializer
+  belongs_to :winner, serializer: TeamSmallSerializer
+  has_many :matches, serializer: MatchSmallSerializer
   # has_many :games
 end

--- a/app/serializers/tournament_serializer.rb
+++ b/app/serializers/tournament_serializer.rb
@@ -1,4 +1,5 @@
 class TournamentSerializer < ActiveModel::Serializer
+  cache key: 'tournaments', expires_in: 1.hour
   attributes :id, :name, :finished, :season, :starts_at, :ends_at
 
   belongs_to :league, serializer: LeagueSmallSerializer

--- a/app/serializers/tournament_serializer.rb
+++ b/app/serializers/tournament_serializer.rb
@@ -1,6 +1,6 @@
 class TournamentSerializer < ActiveModel::Serializer
   cache key: 'tournaments', expires_in: 1.hour
-  attributes :id, :name, :finished, :season, :starts_at, :ends_at
+  attributes :id, :name, :finished, :season, :starts_at, :ends_at, :last_played_at
 
   belongs_to :league, serializer: LeagueSmallSerializer
   belongs_to :series, serializer: SeriesSmallSerializer

--- a/app/serializers/tournament_small_serializer.rb
+++ b/app/serializers/tournament_small_serializer.rb
@@ -1,0 +1,3 @@
+class TournamentSmallSerializer < ActiveModel::Serializer
+  attributes :id, :name, :finished, :season, :starts_at, :ends_at
+end

--- a/app/serializers/tournament_small_serializer.rb
+++ b/app/serializers/tournament_small_serializer.rb
@@ -1,3 +1,4 @@
 class TournamentSmallSerializer < ActiveModel::Serializer
+  cache key: 'tournaments_small', expires_in: 1.hour
   attributes :id, :name, :finished, :season, :starts_at, :ends_at
 end

--- a/app/serializers/tournament_small_serializer.rb
+++ b/app/serializers/tournament_small_serializer.rb
@@ -1,4 +1,4 @@
 class TournamentSmallSerializer < ActiveModel::Serializer
   cache key: 'tournaments_small', expires_in: 1.hour
-  attributes :id, :name, :finished, :season, :starts_at, :ends_at
+  attributes :id, :name, :finished, :season, :starts_at, :ends_at, :last_played_at
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     scope module: :v1, constraints: ApiConstraints.new(version: 1, default: true) do
       resources :leagues, only: [:index, :show], defaults: { format: :json }
       resources :tournaments, only: [:show], defaults: { format: :json }
-      resources :matches, only: [:show], defaults: { format: :json }
+      resources :matches, only: [:index, :show], defaults: { format: :json }
       resources :games, only: [:show], defaults: { format: :json }
       resources :teams, only: [:index, :show], defaults: { format: :json }
       resources :players, only: [:index, :show], defaults: { format: :json }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
       resources :leagues, only: [:index, :show], defaults: { format: :json }
       resources :tournaments, only: [:show], defaults: { format: :json }
       resources :matches, only: [:index, :show], defaults: { format: :json }
-      resources :games, only: [:show], defaults: { format: :json }
+      resources :games, only: [:index, :show], defaults: { format: :json }
       resources :teams, only: [:index, :show], defaults: { format: :json }
       resources :players, only: [:index, :show], defaults: { format: :json }
     end

--- a/db/migrate/20150828234153_add_last_played_at_to_tournaments.rb
+++ b/db/migrate/20150828234153_add_last_played_at_to_tournaments.rb
@@ -1,0 +1,16 @@
+class AddLastPlayedAtToTournaments < ActiveRecord::Migration
+  def up
+    add_column :tournaments, :last_played_at, :datetime
+    add_index :tournaments, :last_played_at
+
+    Tournament.find_each do |tournament|
+      tournament.last_played_at = Match.where(tournament_id: tournament.id, finished: true)
+        .order(played_at: :desc).first.try(:played_at)
+      tournament.save!
+    end
+  end
+
+  def down
+    remove_column :tournaments, :last_played_at
+  end
+end

--- a/db/migrate/20150830162803_add_position_to_plays.rb
+++ b/db/migrate/20150830162803_add_position_to_plays.rb
@@ -1,0 +1,5 @@
+class AddPositionToPlays < ActiveRecord::Migration
+  def change
+    add_column :plays, :position, :integer
+  end
+end

--- a/db/migrate/20150902080656_add_played_at_index_to_matches.rb
+++ b/db/migrate/20150902080656_add_played_at_index_to_matches.rb
@@ -1,0 +1,5 @@
+class AddPlayedAtIndexToMatches < ActiveRecord::Migration
+  def change
+    add_index :matches, :played_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150830162803) do
+ActiveRecord::Schema.define(version: 20150902080656) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -81,6 +81,7 @@ ActiveRecord::Schema.define(version: 20150830162803) do
 
   add_index "matches", ["blue_team_id"], name: "index_matches_on_blue_team_id", using: :btree
   add_index "matches", ["lolesports_id"], name: "index_matches_on_lolesports_id", using: :btree
+  add_index "matches", ["played_at"], name: "index_matches_on_played_at", using: :btree
   add_index "matches", ["red_team_id"], name: "index_matches_on_red_team_id", using: :btree
   add_index "matches", ["tournament_id"], name: "index_matches_on_tournament_id", using: :btree
   add_index "matches", ["winner_id"], name: "index_matches_on_winner_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150817181255) do
+ActiveRecord::Schema.define(version: 20150828234153) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -171,11 +171,13 @@ ActiveRecord::Schema.define(version: 20150817181255) do
     t.integer  "league_id"
     t.integer  "winner_id"
     t.string   "season"
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
     t.integer  "series_id"
+    t.datetime "last_played_at"
   end
 
+  add_index "tournaments", ["last_played_at"], name: "index_tournaments_on_last_played_at", using: :btree
   add_index "tournaments", ["league_id"], name: "index_tournaments_on_league_id", using: :btree
   add_index "tournaments", ["lolesports_id"], name: "index_tournaments_on_lolesports_id", using: :btree
   add_index "tournaments", ["series_id"], name: "index_tournaments_on_series_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150828234153) do
+ActiveRecord::Schema.define(version: 20150830162803) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -129,6 +129,7 @@ ActiveRecord::Schema.define(version: 20150828234153) do
     t.integer  "item3"
     t.integer  "item4"
     t.integer  "item5"
+    t.integer  "position"
   end
 
   add_index "plays", ["game_id"], name: "index_plays_on_game_id", using: :btree

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -73,11 +73,25 @@ RSpec.describe Game, type: :model do
     it { should have_db_column(:youtube_url).of_type(:string) }
   end
 
+  describe '.with_player' do
+    let(:player) { FactoryGirl.create(:player) }
+    let(:play_with_player) { FactoryGirl.create(:play, player: player) }
+    let!(:game_without_player) { FactoryGirl.create(:game) }
+    let!(:game_with_player) do
+      FactoryGirl.create(:game).tap do |game|
+        game.plays << play_with_player
+      end
+    end
+    subject { Game.with_player(player.id) }
+    it { expect(subject).to include(game_with_player) }
+    it { expect(subject).to_not include(game_without_player) }
+  end
+
   describe '#blue_team_players' do
     context 'when no players are assigned' do
       let(:team) { FactoryGirl.create(:team_with_players) }
       let(:game) { FactoryGirl.create(:game, blue_team: team) }
-      it { expect(game.blue_team_players).to eq team.players }
+      it { expect(game.blue_team_players).to include(*team.players) }
     end
 
     context 'when players are assigned' do
@@ -96,7 +110,7 @@ RSpec.describe Game, type: :model do
     context 'when no players are assigned' do
       let(:team) { FactoryGirl.create(:team_with_players) }
       let(:game) { FactoryGirl.create(:game, red_team: team) }
-      it { expect(game.red_team_players).to eq team.players }
+      it { expect(game.red_team_players).to include(*team.players) }
     end
 
     context 'when players are assigned' do

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -41,6 +41,16 @@ RSpec.describe Match, type: :model do
     it { is_expected.to belong_to(:red_team) }
   end
 
+  describe '.with_team' do
+    let(:team) { FactoryGirl.create(:team) }
+    let(:match_one) { FactoryGirl.create(:match, blue_team: team) }
+    let(:match_two) { FactoryGirl.create(:match, red_team: team) }
+    let(:match_three) { FactoryGirl.create(:match) }
+    subject { Match.with_team(team.id) }
+    it { expect(subject).to include(match_one, match_two) }
+    it { expect(subject).to_not include(match_three) }
+  end
+
   describe '#harvest', vcr: true do
     context 'when an api object is not provided' do
       let(:api_match) { LolesportsApi::Match.find(5334) }

--- a/spec/models/play_spec.rb
+++ b/spec/models/play_spec.rb
@@ -83,6 +83,10 @@ RSpec.describe Play, type: :model do
     it { is_expected.to have_db_column(:item0).of_type(:integer) }
   end
 
+  describe '#position' do
+    it { is_expected.to have_db_column(:position).of_type(:integer) }
+  end
+
   describe '#harvest', vcr: true do
     let(:player) { FactoryGirl.create(:player_with_team) }
     let(:game) { FactoryGirl.create(:game) }

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -80,13 +80,6 @@ RSpec.describe Player, type: :model do
     it { is_expected.to have_db_column(:lolesports_id).of_type(:integer) }
   end
 
-  describe 'returns in the proper order' do
-    let!(:shy) { FactoryGirl.create(:player, handle: 'Shy') }
-    let!(:bjergerking) { FactoryGirl.create(:player, handle: 'Bjergsen') }
-
-    it { expect(Player.all).to eq [bjergerking, shy] }
-  end
-
   describe '#harvest', vcr: true do
     context 'when an api object is provided' do
       let(:api_player) { LolesportsApi::Player.find(329) }

--- a/spec/models/tournament_spec.rb
+++ b/spec/models/tournament_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Tournament, type: :model do
     it { is_expected.to have_many(:games) }
   end
 
-  describe '#last_played_at', focus: true do
+  describe '#last_played_at' do
     let!(:tournament) { FactoryGirl.create(:tournament) }
     let!(:match) { FactoryGirl.create(:match, tournament: tournament, finished: true) }
     before do

--- a/spec/models/tournament_spec.rb
+++ b/spec/models/tournament_spec.rb
@@ -33,6 +33,16 @@ RSpec.describe Tournament, type: :model do
     it { is_expected.to have_many(:games) }
   end
 
+  describe '#last_played_at', focus: true do
+    let!(:tournament) { FactoryGirl.create(:tournament) }
+    let!(:match) { FactoryGirl.create(:match, tournament: tournament, finished: true) }
+    before do
+      tournament.reload
+    end
+    it { is_expected.to have_db_column(:last_played_at).of_type(:datetime) }
+    it { expect(tournament.last_played_at).to eq match.played_at }
+  end
+
   describe '#harvest', vcr: true do
     context 'when an api object is not provided' do
       let(:api_tournament) { LolesportsApi::Tournament.find(184) }

--- a/spec/requests/api/v1/games_spec.rb
+++ b/spec/requests/api/v1/games_spec.rb
@@ -1,6 +1,47 @@
 require 'rails_helper'
 
 RSpec.describe 'Games API', type: :request do
+  describe 'GET /api/games' do
+    context 'with no query params' do
+      let!(:game_one) { FactoryGirl.create(:game) }
+      let!(:game_two) { FactoryGirl.create(:game) }
+      before do
+        get api_games_path
+      end
+      it { expect(response).to be_success }
+      it { expect(response.content_type).to eq 'application/json' }
+      it { expect(json['data'].map { |e| e['id'].to_i }).to include(game_one.id, game_two.id) }
+    end
+    context 'with query params' do
+      let(:match) { FactoryGirl.create(:match) }
+      let!(:game_with_match) { FactoryGirl.create(:game, match: match) }
+      let!(:game_without) { FactoryGirl.create(:game) }
+      before do
+        get api_games_path match_id: match.id
+      end
+      it { expect(response).to be_success }
+      it { expect(response.content_type).to eq 'application/json' }
+      it { expect(json['data'].map { |e| e['id'].to_i }).to include(game_with_match.id) }
+      it { expect(json['data'].map { |e| e['id'].to_i }).to_not include(game_without.id) }
+    end
+    context 'with player_id query param' do
+      let(:player) { FactoryGirl.create(:player) }
+      let!(:game_without_player) { FactoryGirl.create(:game) }
+      let!(:game_with_player) do
+        FactoryGirl.create(:game).tap do |game|
+          game.players << player
+        end
+      end
+      before do
+        get api_games_path player_id: player.id
+      end
+      it { expect(response).to be_success }
+      it { expect(response.content_type).to eq 'application/json' }
+      it { expect(json['data'].map { |e| e['id'].to_i }).to include(game_with_player.id) }
+      it { expect(json['data'].map { |e| e['id'].to_i }).to_not include(game_without_player.id) }
+    end
+  end
+
   describe 'GET /api/games/:id' do
     let(:game) { FactoryGirl.create(:game_with_full_teams) }
     before do

--- a/spec/requests/api/v1/matches_spec.rb
+++ b/spec/requests/api/v1/matches_spec.rb
@@ -24,6 +24,18 @@ RSpec.describe 'Api::V1::Matches', type: :request do
       it { expect(json['data'].map { |e| e['id'].to_i }).to include(match_one.id) }
       it { expect(json['data'].map { |e| e['id'].to_i }).to_not include(match_two.id) }
     end
+    context 'with team_id query param' do
+      let(:team) { FactoryGirl.create(:team) }
+      let!(:match_one) { FactoryGirl.create(:match, blue_team: team) }
+      let!(:match_two) { FactoryGirl.create(:match) }
+      before do
+        get api_matches_path team_id: team.id
+      end
+      it { expect(response).to be_success }
+      it { expect(response.content_type).to eq 'application/json' }
+      it { expect(json['data'].map { |e| e['id'].to_i }).to include(match_one.id) }
+      it { expect(json['data'].map { |e| e['id'].to_i }).to_not include(match_two.id) }
+    end
   end
 
   describe 'GET /api/matches/:id' do

--- a/spec/requests/api/v1/matches_spec.rb
+++ b/spec/requests/api/v1/matches_spec.rb
@@ -1,6 +1,31 @@
 require 'rails_helper'
 
 RSpec.describe 'Api::V1::Matches', type: :request do
+  describe 'GET /api/matches' do
+    context 'with no query params' do
+      let!(:match_one) { FactoryGirl.create(:match) }
+      let!(:match_two) { FactoryGirl.create(:match) }
+      before do
+        get api_matches_path
+      end
+      it { expect(response).to be_success }
+      it { expect(response.content_type).to eq 'application/json' }
+      it { expect(json['data'].map { |e| e['id'].to_i }).to include(match_one.id, match_two.id) }
+    end
+    context 'with query params' do
+      let(:tournament) { FactoryGirl.create(:tournament) }
+      let!(:match_one) { FactoryGirl.create(:match, tournament: tournament) }
+      let!(:match_two) { FactoryGirl.create(:match) }
+      before do
+        get api_matches_path tournament_id: tournament.id
+      end
+      it { expect(response).to be_success }
+      it { expect(response.content_type).to eq 'application/json' }
+      it { expect(json['data'].map { |e| e['id'].to_i }).to include(match_one.id) }
+      it { expect(json['data'].map { |e| e['id'].to_i }).to_not include(match_two.id) }
+    end
+  end
+
   describe 'GET /api/matches/:id' do
     let(:match) { FactoryGirl.create(:match_with_games) }
     before do


### PR DESCRIPTION
So, this is the second, and hopefully last, large changelist made from updating the API to keep up with the new lolesports data additions.
- Adds 'position' to Plays, based on the consistent order coming from the lolesports.com API.
- Adds kaminari to support pagination over large index API endpoints.
- Adds `games#index`.
- Adds `matches#index`.
- Adds SmallSerializer versions of all serializers, to increase `includes:` performance when generating JSON.
